### PR TITLE
use go-terraform-address to parse address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/google/go-cmp v0.5.1
+	github.com/hashicorp/go-terraform-address v0.0.0-20200814224554-3a484c5d5284
 	github.com/mattn/go-colorable v0.1.7
 	golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/hashicorp/go-terraform-address v0.0.0-20200814224554-3a484c5d5284 h1:XK/E8kLm/HGwik4GByK4tC9vTZ26Mp51OH3Q6Tv6Xqg=
+github.com/hashicorp/go-terraform-address v0.0.0-20200814224554-3a484c5d5284/go.mod h1:xoy1vl2+4YvqSQEkKcFjNYxTk7cll+o1f1t2wxnHIX8=
 github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3mdw=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -11,3 +17,5 @@ golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9 h1:yi1hN8dcqI9l8klZfy4B8mJvF
 golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/resource_test.go
+++ b/resource_test.go
@@ -239,6 +239,10 @@ func TestNewResourceChangeFromComment(t *testing.T) {
 				t.Fatalf("Expected an error but didn't get one")
 			}
 
+			if err != nil && !tc.shouldError {
+				t.Fatalf("Unexpected error %v", err)
+			}
+
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Fatalf("Expected: %v but got %v", tc.expected, got)
 			}


### PR DESCRIPTION
This PR updates parsing resource addresses to use [`hashicorp/go-terraform-address`](https://github.com/hashicorp/go-terraform-address).

This PR will not be merged for now because it does not handle `data` paths:
- `data.mydata.path`
- `module.mymodule.data.mydata.path`
- `module.mymodule.data.data.data`

```
--- FAIL: TestNewResourceChangeFromComment (0.00s)
    --- FAIL: TestNewResourceChangeFromComment/handles_modules_with_data_and_data_as_the_name (0.00s)
        resource_test.go:243: Unexpected error 1:26 (25): no match found, expected: "[", [a-zA-Z0-9_-]i or EOF
    --- FAIL: TestNewResourceChangeFromComment/handles_modules_with_data (0.00s)
        resource_test.go:243: Unexpected error 1:28 (27): no match found, expected: "[", [a-zA-Z0-9_-]i or EOF
    --- FAIL: TestNewResourceChangeFromComment/handles_data (0.00s)
        resource_test.go:243: Unexpected error 1:12 (11): no match found, expected: "[", [a-zA-Z0-9_-]i or EOF
```