### PR TITLE
handle no-ops properly, initialize jsonencode

### DIFF
--- a/array_attribute.go
+++ b/array_attribute.go
@@ -21,9 +21,9 @@ type ArrayAttributeChange struct {
 // This requires the line to start with "+", "-" or "~", not be followed with "resource" or "data", and ends with "[".
 func IsArrayAttributeChangeLine(line string) bool {
 	line = strings.TrimSpace(line)
-	validPrefix := strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "~")
+	// validPrefix := strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "~")
 	validSuffix := strings.HasSuffix(line, "[") || IsOneLineEmptyArrayAttribute(line)
-	return validPrefix && validSuffix && !IsResourceChangeLine(line)
+	return validSuffix && !IsResourceChangeLine(line)
 }
 
 // IsArrayAttributeTerminator returns true if the line is "]" or "] -> null"
@@ -64,7 +64,10 @@ func NewArrayAttributeChangeFromLine(line string) (*ArrayAttributeChange, error)
 			UpdateType: UpdateInPlaceResource,
 		}, nil
 	} else {
-		return nil, fmt.Errorf("unrecognized line pattern")
+		return &ArrayAttributeChange{
+			Name:       attributeName,
+			UpdateType: NoOpResource,
+		}, nil
 	}
 }
 

--- a/array_attribute_test.go
+++ b/array_attribute_test.go
@@ -66,13 +66,27 @@ func TestNewArrayAttributeChangeFromLine(t *testing.T) {
 		},
 		"attribute is unchanged": {
 			line:        `attribute [`,
-			shouldError: true,
-			expected:    nil,
+			shouldError: false,
+			expected: &ArrayAttributeChange{
+				Name:       "attribute",
+				UpdateType: NoOpResource,
+			},
 		},
 		"attribute with delimiter is unchanged": {
 			line:        `attribute = [`,
-			shouldError: true,
-			expected:    nil,
+			shouldError: false,
+			expected: &ArrayAttributeChange{
+				Name:       "attribute",
+				UpdateType: NoOpResource,
+			},
+		},
+		"unchanged empty array": {
+			line:        `attribute = []`,
+			shouldError: false,
+			expected: &ArrayAttributeChange{
+				Name:       "attribute",
+				UpdateType: NoOpResource,
+			},
 		},
 		"resource line": {
 			line:        `+ resource "type" "name" {`,

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -36,7 +36,7 @@ func TestIsAttributeChangeLine(t *testing.T) {
 		},
 		"attribute is unchanged": {
 			line:     `attribute = "old"`,
-			expected: false,
+			expected: true,
 		},
 		"resource line": {
 			line:     `+ resource "type" "name" {`,
@@ -121,16 +121,6 @@ func TestNewAttributeChangeFromLine(t *testing.T) {
 				UpdateType: DestroyResource,
 			},
 		},
-		"empty map is deleted": {
-			line:        `- attribute {}`,
-			shouldError: false,
-			expected: &AttributeChange{
-				Name:       "attribute",
-				OldValue:   nil,
-				NewValue:   nil,
-				UpdateType: DestroyResource,
-			},
-		},
 		"attribute changed": {
 			line:        `~ attribute = "old" -> "new"`,
 			shouldError: false,
@@ -173,8 +163,13 @@ func TestNewAttributeChangeFromLine(t *testing.T) {
 		},
 		"attribute is unchanged": {
 			line:        `attribute = "old"`,
-			shouldError: true,
-			expected:    nil,
+			shouldError: false,
+			expected: &AttributeChange{
+				Name:       "attribute",
+				OldValue:   "old",
+				NewValue:   "old",
+				UpdateType: NoOpResource,
+			},
 		},
 		"resource line": {
 			line:        `+ resource "type" "name" {`,

--- a/jsonencode.go
+++ b/jsonencode.go
@@ -1,0 +1,3 @@
+package tfplanparse
+
+// TODO implement

--- a/map_attribute.go
+++ b/map_attribute.go
@@ -18,14 +18,14 @@ type MapAttributeChange struct {
 // This requires the line to start with "+", "-" or "~", not be followed with "resource" or "data", and ends with "{".
 func IsMapAttributeChangeLine(line string) bool {
 	line = strings.TrimSpace(line)
-	validPrefix := strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "~")
+	// validPrefix := strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "~")
 	validSuffix := strings.HasSuffix(line, "{") || IsOneLineEmptyMapAttribute(line)
-	return validPrefix && validSuffix && !IsResourceChangeLine(line)
+	return validSuffix && !IsResourceChangeLine(line)
 }
 
-// IsMapAttributeTerminator returns true if the line is a "}"
+// IsMapAttributeTerminator returns true if the line is a "}" or "},"
 func IsMapAttributeTerminator(line string) bool {
-	return strings.TrimSpace(line) == "}"
+	return strings.TrimSuffix(strings.TrimSpace(line), ",") == "}"
 }
 
 // IsOneLineEmptyMapAttribute returns true if the line ends with a "{}"
@@ -61,7 +61,10 @@ func NewMapAttributeChangeFromLine(line string) (*MapAttributeChange, error) {
 			UpdateType: UpdateInPlaceResource,
 		}, nil
 	} else {
-		return nil, fmt.Errorf("unrecognized line pattern")
+		return &MapAttributeChange{
+			Name:       attributeName,
+			UpdateType: NoOpResource,
+		}, nil
 	}
 }
 

--- a/map_attribute_test.go
+++ b/map_attribute_test.go
@@ -66,13 +66,27 @@ func TestNewMapAttributeChangeFromLine(t *testing.T) {
 		},
 		"attribute is unchanged": {
 			line:        `attribute {`,
-			shouldError: true,
-			expected:    nil,
+			shouldError: false,
+			expected: &MapAttributeChange{
+				Name:       "attribute",
+				UpdateType: NoOpResource,
+			},
 		},
 		"attribute with delimiter is unchanged": {
 			line:        `attribute = {`,
-			shouldError: true,
-			expected:    nil,
+			shouldError: false,
+			expected: &MapAttributeChange{
+				Name:       "attribute",
+				UpdateType: NoOpResource,
+			},
+		},
+		"unchanged empty map": {
+			line:        `attribute = {}`,
+			shouldError: false,
+			expected: &MapAttributeChange{
+				Name:       "attribute",
+				UpdateType: NoOpResource,
+			},
 		},
 		"resource line": {
 			line:        `+ resource "type" "name" {`,

--- a/parse.go
+++ b/parse.go
@@ -192,7 +192,7 @@ func parseArrayAttribute(s *bufio.Scanner) (*ArrayAttributeChange, error) {
 				return nil, err
 			}
 			result.HeredocAttributeChanges = append(result.HeredocAttributeChanges, ha)
-		case IsAttributeChangeLine(text):
+		case IsAttributeChangeArrayItem(text):
 			if len(result.AttributeChanges) > 0 && (len(result.MapAttributeChanges) > 0 || len(result.ArrayAttributeChanges) > 0) {
 				return nil, fmt.Errorf("detected a single attribute in an array with map or array attribute changes")
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -86,20 +86,74 @@ func TestParse(t *testing.T) {
 			file: "test/nestedmap.stdout",
 			expected: []*ResourceChange{
 				&ResourceChange{
-					Address:          "module.mymodule.kubernetes_namespace.mynamespace",
-					ModuleAddress:    "module.mymodule",
-					Type:             "kubernetes_namespace",
-					Name:             "mynamespace",
-					UpdateType:       UpdateInPlaceResource,
-					AttributeChanges: nil,
+					Address:       "module.mymodule.kubernetes_namespace.mynamespace",
+					ModuleAddress: "module.mymodule",
+					Type:          "kubernetes_namespace",
+					Name:          "mynamespace",
+					UpdateType:    UpdateInPlaceResource,
+					AttributeChanges: []*AttributeChange{
+						&AttributeChange{
+							Name:       "id",
+							OldValue:   "namespace-id",
+							NewValue:   "namespace-id",
+							UpdateType: NoOpResource,
+						},
+					},
 					MapAttributeChanges: []*MapAttributeChange{
 						&MapAttributeChange{
-							Name:             "metadata",
-							AttributeChanges: nil,
+							Name: "metadata",
+							AttributeChanges: []*AttributeChange{
+								&AttributeChange{
+									Name:       "generation",
+									OldValue:   0,
+									NewValue:   0,
+									UpdateType: NoOpResource,
+								},
+								&AttributeChange{
+									Name:       "name",
+									OldValue:   "my-namespace",
+									NewValue:   "my-namespace",
+									UpdateType: NoOpResource,
+								},
+								&AttributeChange{
+									Name:       "resource_version",
+									OldValue:   "123",
+									NewValue:   "123",
+									UpdateType: NoOpResource,
+								},
+								&AttributeChange{
+									Name:       "self_link",
+									OldValue:   "/api/v1/namespaces/my-namespace",
+									NewValue:   "/api/v1/namespaces/my-namespace",
+									UpdateType: NoOpResource,
+								},
+								&AttributeChange{
+									Name:       "uid",
+									OldValue:   "some-uid-123",
+									NewValue:   "some-uid-123",
+									UpdateType: NoOpResource,
+								},
+							},
 							MapAttributeChanges: []*MapAttributeChange{
+								&MapAttributeChange{
+									Name:       "annotations",
+									UpdateType: NoOpResource,
+								},
 								&MapAttributeChange{
 									Name: "labels",
 									AttributeChanges: []*AttributeChange{
+										&AttributeChange{
+											Name:       "label",
+											OldValue:   "value",
+											NewValue:   "value",
+											UpdateType: NoOpResource,
+										},
+										&AttributeChange{
+											Name:       "other",
+											OldValue:   "label",
+											NewValue:   "label",
+											UpdateType: NoOpResource,
+										},
 										&AttributeChange{
 											Name:       "newLabel",
 											OldValue:   nil,
@@ -112,6 +166,10 @@ func TestParse(t *testing.T) {
 								},
 							},
 							UpdateType: UpdateInPlaceResource,
+						},
+						&MapAttributeChange{
+							Name:       "timeouts",
+							UpdateType: NoOpResource,
 						},
 					},
 				},


### PR DESCRIPTION
This PR finalizes version 0.0.6.

It adds handling of no-op(unchanged) resources and initializes `jsonencode` for next release.