### PR TITLE
parser: Handle comments

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -75,7 +75,7 @@ func parseResource(s *bufio.Scanner) (*ResourceChange, error) {
 		switch {
 		case IsResourceTerminator(text):
 			return rc, nil
-		case IsResourceCommentLine(text), strings.Contains(text, CHANGES_END_STRING):
+		case strings.Contains(text, CHANGES_END_STRING):
 			return nil, fmt.Errorf("unexpected line while parsing resource attribute: %s", text)
 		case IsMapAttributeChangeLine(text):
 			ma, err := parseMapAttribute(s)
@@ -107,6 +107,8 @@ func parseResource(s *bufio.Scanner) (*ResourceChange, error) {
 				return nil, err
 			}
 			rc.AttributeChanges = append(rc.AttributeChanges, ac)
+		case IsComment(text):
+			continue
 		}
 	}
 
@@ -128,7 +130,7 @@ func parseMapAttribute(s *bufio.Scanner) (*MapAttributeChange, error) {
 		switch {
 		case IsMapAttributeTerminator(text):
 			return result, nil
-		case IsResourceCommentLine(text), strings.Contains(text, CHANGES_END_STRING):
+		case strings.Contains(text, CHANGES_END_STRING):
 			return nil, fmt.Errorf("unexpected line while parsing map attribute: %s", text)
 		case IsMapAttributeChangeLine(text):
 			ma, err := parseMapAttribute(s)
@@ -160,6 +162,8 @@ func parseMapAttribute(s *bufio.Scanner) (*MapAttributeChange, error) {
 				return nil, err
 			}
 			result.AttributeChanges = append(result.AttributeChanges, ac)
+		case IsComment(text):
+			continue
 		}
 	}
 
@@ -181,7 +185,7 @@ func parseArrayAttribute(s *bufio.Scanner) (*ArrayAttributeChange, error) {
 		switch {
 		case IsArrayAttributeTerminator(text):
 			return result, nil
-		case IsResourceCommentLine(text), strings.Contains(text, CHANGES_END_STRING):
+		case strings.Contains(text, CHANGES_END_STRING):
 			return nil, fmt.Errorf("unexpected line while parsing array attribute: %s", text)
 		case IsMapAttributeChangeLine(text):
 			ma, err := parseMapAttribute(s)
@@ -213,6 +217,8 @@ func parseArrayAttribute(s *bufio.Scanner) (*ArrayAttributeChange, error) {
 				return nil, err
 			}
 			result.AttributeChanges = append(result.AttributeChanges, ac)
+		case IsComment(text):
+			continue
 		}
 	}
 
@@ -232,7 +238,7 @@ func parseJSONEncodeAttribute(s *bufio.Scanner) (*JSONEncodeAttributeChange, err
 		switch {
 		case IsJSONEncodeAttributeTerminator(text):
 			return result, nil
-		case IsResourceCommentLine(text), strings.Contains(text, CHANGES_END_STRING):
+		case strings.Contains(text, CHANGES_END_STRING):
 			return nil, fmt.Errorf("unexpected line while parsing jsonencode attribute: %s", text)
 		case IsMapAttributeChangeLine(text):
 			ma, err := parseMapAttribute(s)
@@ -260,6 +266,8 @@ func parseJSONEncodeAttribute(s *bufio.Scanner) (*JSONEncodeAttributeChange, err
 				return nil, err
 			}
 			result.AttributeChanges = append(result.AttributeChanges, ac)
+		case IsComment(text):
+			continue
 		}
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -334,6 +334,18 @@ func TestParse(t *testing.T) {
 			file: "test/anothermap.stdout",
 			expected: []*ResourceChange{
 				&ResourceChange{
+					Address:       "module.mymodule.data.kubernetes_config_map.my_configmap",
+					ModuleAddress: "module.mymodule",
+					Type:          "kubernetes_config_map",
+					Name:          "my_configmap",
+					UpdateType:    "read",
+					AttributeChanges: []attributeChange{
+						&AttributeChange{Name: "id", NewValue: string("(known after apply)"), UpdateType: "created"},
+						&AttributeChange{Name: "name", NewValue: string("my-configmap"), UpdateType: "created"},
+						&AttributeChange{Name: "namespace", NewValue: string("my-namespace"), UpdateType: "created"},
+					},
+				},
+				&ResourceChange{
 					Address:       "module.mymodule.kubernetes_role_binding.user_is_edit",
 					ModuleAddress: "module.mymodule",
 					Type:          "kubernetes_role_binding",
@@ -820,7 +832,7 @@ func TestParse(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(got, tc.expected); diff != "" {
-				t.Errorf("(-got, +expected)\n%s", diff)
+				t.Errorf("(-want, +got)\n%s", diff)
 			}
 		})
 	}

--- a/resource.go
+++ b/resource.go
@@ -46,12 +46,30 @@ type ResourceChange struct {
 	AttributeChanges []attributeChange
 }
 
-// IsResourceCommentLine returns true if the line is a valid resource comment line
-// A valid line starts with a "#" and has a suffix describing the change
+// IsComment returns true if the line is a comment.
+//
+// A valid line starts with a "#".
+func IsComment(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "#")
+}
+
+// IsResourceCommentLine returns true if the line is a resource "header" comment line
+// A valid line starts with a "#" and ends with a known resource change suffix
 // Example: # module.type.item will be created
 func IsResourceCommentLine(line string) bool {
-	trimmed := strings.TrimSpace(line)
-	return strings.HasPrefix(trimmed, "#") && !strings.HasSuffix(trimmed, RESOURCE_READ_VALUES_NOT_YET_KNOWN)
+	line = strings.TrimSpace(line)
+
+	if !IsComment(line) {
+		return false
+	}
+
+	for _, suffix := range resourceCommentSuffixes {
+		if strings.HasSuffix(line, suffix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // IsResourceTerminator returns true if the line is a "}"
@@ -218,4 +236,9 @@ attrs:
 
 func parseResourceAddressFromComment(comment, updateText string) string {
 	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(comment, "# "), updateText))
+}
+
+var resourceCommentSuffixes = []string{
+	RESOURCE_CREATED, RESOURCE_DESTROYED, RESOURCE_READ,
+	RESOURCE_REPLACED, RESOURCE_TAINTED, RESOURCE_UPDATED_IN_PLACE,
 }

--- a/test/anothermap.stdout
+++ b/test/anothermap.stdout
@@ -7,6 +7,15 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
+
+# module.mymodule.data.kubernetes_config_map.my_configmap will be read during apply
+# (depends on a resource or a module with changes pending)
+<= data "kubernetes_config_map" "my_configmap" {
+     + id        = (known after apply)
+     + name      = "my-configmap"
+     + namespace = "my-namespace"
+}
+
 # module.mymodule.kubernetes_role_binding.user_is_edit will be created
   + resource "kubernetes_role_binding" "user_is_edit" {
       + id = (known after apply)

--- a/test/nestedmap.stdout
+++ b/test/nestedmap.stdout
@@ -17,14 +17,17 @@ Terraform will perform the following actions:
                 "label"    = "value"
                 "other"    = "label"
               + "newLabel" = "newLabel"
+                # (5 unchanged elements hidden)
             }
             name             = "my-namespace"
             resource_version = "123"
             self_link        = "/api/v1/namespaces/my-namespace"
             uid              = "some-uid-123"
+            # (8 unchanged attributes hidden)
         }
 
         timeouts {}
+        # (1 unchanged block hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.


### PR DESCRIPTION
Plans can contain comments within resources or immediately after the comment describing the resource being added/deleted/updated.

Currently, this leads to errors such as:

> Error: unexpected line while parsing resource attribute: # (depends on a resource or a module with changes pending)

The `IsComment` case has been relegated to the final check so that any specific comment handling can occur before it.

The change to `IsResourceCommentLine` slightly increases strictness, especially useful if more specific comments are added or considered significant.