### PR TITLE
add support for changes to computed arrays and maps

### DIFF
--- a/array_attribute.go
+++ b/array_attribute.go
@@ -27,7 +27,7 @@ func IsArrayAttributeChangeLine(line string) bool {
 
 // IsArrayAttributeTerminator returns true if the line is "]" or "] -> null"
 func IsArrayAttributeTerminator(line string) bool {
-	return strings.TrimSuffix(strings.TrimSpace(line), " -> null") == "]"
+	return strings.TrimSuffix(strings.TrimSpace(line), " -> null") == "]" || strings.TrimSuffix(strings.TrimSpace(line), " -> (known after apply)") == "]"
 }
 
 // IsOneLineEmptyArrayAttribute returns true if the line ends with a "[]"

--- a/map_attribute.go
+++ b/map_attribute.go
@@ -24,7 +24,7 @@ func IsMapAttributeChangeLine(line string) bool {
 
 // IsMapAttributeTerminator returns true if the line is a "}" or "},"
 func IsMapAttributeTerminator(line string) bool {
-	return strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(line), ","), " -> null") == "}"
+	return strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(line), ","), " -> null") == "}" || strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(line), ","), " -> (known after apply)") == "}"
 }
 
 // IsOneLineEmptyMapAttribute returns true if the line ends with a "{}"

--- a/parse_test.go
+++ b/parse_test.go
@@ -242,6 +242,71 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		"computedmap": {
+			file: "test/computedobject.stdout",
+			expected: []*ResourceChange{
+				&ResourceChange{
+					Address:       "module.my-project.google_project_services.gcp_enabled_services[0]",
+					ModuleAddress: "module.my-project",
+					Type:          "google_project_services",
+					Name:          "gcp_enabled_services",
+					Index:         0,
+					UpdateType:    UpdateInPlaceResource,
+					AttributeChanges: []attributeChange{
+						&AttributeChange{
+							Name:       "disable_on_destroy",
+							OldValue:   false,
+							NewValue:   true,
+							UpdateType: UpdateInPlaceResource,
+						},
+						&AttributeChange{
+							Name:       "id",
+							OldValue:   "my-project",
+							NewValue:   "test",
+							UpdateType: UpdateInPlaceResource,
+						},
+						&AttributeChange{
+							Name:       "project",
+							OldValue:   "my-project",
+							NewValue:   "test2",
+							UpdateType: UpdateInPlaceResource,
+						},
+						&ArrayAttributeChange{
+							Name: "computed_services",
+							AttributeChanges: []attributeChange{
+								&AttributeChange{
+									OldValue:   "appengine.googleapis.com",
+									NewValue:   nil,
+									UpdateType: DestroyResource,
+								},
+								&AttributeChange{
+									OldValue:   "audit.googleapis.com",
+									NewValue:   nil,
+									UpdateType: DestroyResource,
+								},
+							},
+							UpdateType: UpdateInPlaceResource,
+						},
+						&MapAttributeChange{
+							Name: "computed_tags",
+							AttributeChanges: []attributeChange{
+								&AttributeChange{
+									Name:       "key1",
+									OldValue:   "old",
+									NewValue:   "new",
+									UpdateType: UpdateInPlaceResource,
+								},
+							},
+							UpdateType: UpdateInPlaceResource,
+						},
+						&MapAttributeChange{
+							Name:       "timeouts",
+							UpdateType: UpdateInPlaceResource,
+						},
+					},
+				},
+			},
+		},
 		"nested map": {
 			file: "test/nestedmap.stdout",
 			expected: []*ResourceChange{

--- a/test/computedobject.stdout
+++ b/test/computedobject.stdout
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # module.my-project.google_project_services.gcp_enabled_services[0] will be updated in-place
+  ~ resource "google_project_services" "gcp_enabled_services" {
+      ~ disable_on_destroy = false -> true
+      ~ id                 = "my-project" -> "test"
+      ~ project            = "my-project" -> "test2"
+      ~ computed_services           = [
+          - "appengine.googleapis.com",
+          - "audit.googleapis.com",
+        ] -> (known after apply)
+      ~ computed_tags              = {
+          ~ key1    = "old" -> "new"
+        } -> (known after apply)
+      ~ timeouts {}
+    }
+
+Plan: 0 to add, 0 to change, 1 to destroy.


### PR DESCRIPTION
Currently, if the diff includes a map or array that is computed, the parser will fail.  This is because it assumes that the only way a map or array could be changed at a top level, is if it gets nulled out.  Otherwise any changes would appear in the body of the array or map.  So this works:

```
      - services           = [
          - "appengine.googleapis.com",
          - "audit.googleapis.com",
        ] -> null
```

However if the map or array is set to computed, such that its value is (known after apply), then the format of the plan is similar to the whole map or array being replaced, but doesn't end in "null", so the parsing logic doesn't know what to do.

```
      ~ services           = [
          - "appengine.googleapis.com",
          - "audit.googleapis.com",
        ] -> (known after apply)
```

This PR adds the `(known after apply)` as an alternative expected ending to an array or map field.  Tests have been included to validate the new behavior.